### PR TITLE
Fix typo, rename `dbName` to `db`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,25 +40,23 @@ Firebolt ([May 11, 2022 version](https://docs.firebolt.io/general-reference/rele
 | `db`             | The name of your database.                                                          | **true** | `some_database`                                          |
 | `table`          | The name of a table in the database that the connector should write to, by default. | **true** | `some_table`                                             |
 
-
 ## Source
 
 ### Configuration
 
 The config passed to `Configure` can contain the following fields.
 
-| name                | description                                                                                                                                            | required  | example                           |
-|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-----------------------------------|
-| `email`             | Firebolt user email.                                                                                                                                   | **true**  | email@test.com                    |
-| `password`          | Password for firebolt account.                                                                                                                         | **true**  | password                          |
-| `engineEndpoint`    | Firebolt databse endpoint engine.                                                                                                                      | **true**  | test.test_company.app.firebolt.io |
-| `dbName`            | Database name.                                                                                                                                         | **true**  | test                              |
-| `table`             | Table name.                                                                                                                                            | **true**  | clients                           |
-| `orderingColumn`    | Column which using for ordering in select query . Usually it is can be pk or timestamp column                                                          | **true**  | created_date                      |
-| `columns`           | Comma separated list of column names that should be included in each Record's payload. By default: all columns.                                        | **false** | "id,name,age"                     |
-| `primaryKey`        | Column name that records should use for their `Key` fields.                                                                                            | **true**  | "id"                              |
-| `batchSize`         | Size of batch. By default is 1000. <b>Important:</b> Please don't update this variable after the pipeline starts, it will cause problem with position. | **false** | "100"                             |
-
+| name             | description                                                                                                                                            | required  | example                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | --------------------------------- |
+| `email`          | Firebolt user email.                                                                                                                                   | **true**  | email@test.com                    |
+| `password`       | Password for firebolt account.                                                                                                                         | **true**  | password                          |
+| `engineEndpoint` | Firebolt databse endpoint engine.                                                                                                                      | **true**  | test.test_company.app.firebolt.io |
+| `db`             | Database name.                                                                                                                                         | **true**  | test                              |
+| `table`          | Table name.                                                                                                                                            | **true**  | clients                           |
+| `orderingColumn` | Column which using for ordering in select query . Usually it is can be pk or timestamp column                                                          | **true**  | created_date                      |
+| `columns`        | Comma separated list of column names that should be included in each Record's payload. By default: all columns.                                        | **false** | "id,name,age"                     |
+| `primaryKey`     | Column name that records should use for their `Key` fields.                                                                                            | **true**  | "id"                              |
+| `batchSize`      | Size of batch. By default is 1000. <b>Important:</b> Please don't update this variable after the pipeline starts, it will cause problem with position. | **false** | "100"                             |
 
 ### Snapshot iterator
 
@@ -69,15 +67,14 @@ Iterator HasNext method check if next element exist in currentBatch using variab
 and run select query to get new data with new offset. Method `Next` gets next element and converts it to `Record` sets metadata variable table,
 set metadata variable action - `insert`, increases index.
 
-
 Example of position:
+
 ```json
 {
- "IndexInBatch": 2,
- "BatchID": 10
+  "IndexInBatch": 2,
+  "BatchID": 10
 }
 ```
-
 
 If snapshot stops, it will parse position from last record. Position has fields: `IndexInBatch` - it is the index of element
 in current batch, this last element what was recorded, `BatchID` - shows the last value offset what iterator used for
@@ -85,21 +82,19 @@ getting data query. Iterator runs query to get data from table with `batchSize` 
 position. `index` value will be `Element` increased by one, because iterator tries to find next element in current batch.
 If `index` > `batchSize` iterator will change `BatchID` to next and set `index` zero.
 
-
 For example, we get snapshot position in `Open` function:
+
 ```json
 {
- "IndexInBatch": 4,
- "BatchID": 20
+  "IndexInBatch": 4,
+  "BatchID": 20
 }
 ```
 
-
 Last recorded position has `BatchID` = 20, it is means iterator did last time query with `offset` value 20, iterator will
-do the same query with the  same `offset` value. Iterator gets batch with rows from table. `IndexInBatch` it is last
+do the same query with the same `offset` value. Iterator gets batch with rows from table. `IndexInBatch` it is last
 index for element in this batch what was processed. Iterator looks for next element in batch (with index = 5) and convert
 it to record.
-
 
 ### CDC iterator
 


### PR DESCRIPTION
### Description

Fix typo, rename `dbName` to `db`

### Quick checks:

- [x] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [x] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-snowflake/pulls) for the same update/change.
- [x] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.
